### PR TITLE
fix: restore 7 truncated verses (JFAA, AS21, KJF)

### DIFF
--- a/data/canonical/AS21/EZK.json
+++ b/data/canonical/AS21/EZK.json
@@ -5042,7 +5042,7 @@
         },
         {
           "number": 12,
-          "text": "Quando o príncipe trouxer uma oferta voluntária, holocausto, ou ofertas pacíficas, como oferta voluntária ao"
+          "text": "Quando o príncipe trouxer uma oferta voluntária, holocausto, ou ofertas pacíficas, como oferta voluntária ao SENHOR, a porta que dá para o oriente será aberta, e ele oferecerá seu holocausto e suas ofertas pacíficas, como tiver feito no dia de sábado. Então sairá, e a porta será fechada depois que ele sair."
         },
         {
           "number": 13,

--- a/data/canonical/AS21/JER.json
+++ b/data/canonical/AS21/JER.json
@@ -4580,7 +4580,7 @@
         },
         {
           "number": 26,
-          "text": "Ouvi a palavra do SENHOR, todos os de Judá que habitais na terra do Egito: Juro pelo meu grande nome, diz o"
+          "text": "Ouvi a palavra do SENHOR, todos os de Judá que habitais na terra do Egito: Juro pelo meu grande nome, diz o SENHOR, que nunca mais será pronunciado o meu nome pela boca de nenhum homem de Judá em toda a terra do Egito, dizendo: Como vive o SENHOR Deus!"
         },
         {
           "number": 27,

--- a/data/canonical/JFAA/1TI.json
+++ b/data/canonical/JFAA/1TI.json
@@ -337,7 +337,7 @@
         },
         {
           "number": 11,
-          "text": "Mas rejeita as viúvas mais novas, porque, quando se tornam le5"
+          "text": "Mas rejeita as viúvas mais novas, porque, quando se tornam levianas contra Cristo, querem casar-se;"
         },
         {
           "number": 12,

--- a/data/canonical/JFAA/EXO.json
+++ b/data/canonical/JFAA/EXO.json
@@ -3050,7 +3050,7 @@
         },
         {
           "number": 27,
-          "text": "e cinco para as tábuas do outro lado do tabernáculo, bem como c6 azeite para a luz, especiarias para o óleo da unção e para o para o ocidente."
+          "text": "e cinco para as tábuas do outro lado do tabernáculo, bem como o azeite para a luz, especiarias para o óleo da unção e para o para o ocidente."
         },
         {
           "number": 28,

--- a/data/canonical/JFAA/JDG.json
+++ b/data/canonical/JFAA/JDG.json
@@ -1045,7 +1045,7 @@
         },
         {
           "number": 4,
-          "text": "E deram-lhe setenta siclos de prata, da casa de Baal-Berite, com os quais alugou Abimeleque alguns homens ociosos e le9"
+          "text": "E deram-lhe setenta siclos de prata, da casa de Baal-Berite, com os quais alugou Abimeleque alguns homens ociosos e levianas, que o seguiram;"
         },
         {
           "number": 5,

--- a/data/canonical/JFAA/JER.json
+++ b/data/canonical/JFAA/JER.json
@@ -912,7 +912,7 @@
         },
         {
           "number": 11,
-          "text": "E curam a ferida da filha de meu povo le23"
+          "text": "E curam a ferida da filha de meu povo levianamente, dizendo: Paz, paz; quando não há paz."
         },
         {
           "number": 12,

--- a/data/canonical/KJF/2SA.json
+++ b/data/canonical/KJF/2SA.json
@@ -1353,7 +1353,7 @@
         },
         {
           "number": 27,
-          "text": "Absalão, porém, insistiu com ele para"
+          "text": "Absalão, porém, insistiu com ele para que deixasse Amnom e todos os filhos do rei irem com ele."
         },
         {
           "number": 28,

--- a/data/corrections/AS21.json
+++ b/data/corrections/AS21.json
@@ -1,0 +1,26 @@
+[
+  {
+    "book": "JER",
+    "chapter": 44,
+    "verse": 26,
+    "was": "Ouvi a palavra do SENHOR, todos os de Judá que habitais na terra do Egito: Juro pelo meu grande nome, diz o",
+    "now": "Ouvi a palavra do SENHOR, todos os de Judá que habitais na terra do Egito: Juro pelo meu grande nome, diz o SENHOR, que nunca mais será pronunciado o meu nome pela boca de nenhum homem de Judá em toda a terra do Egito, dizendo: Como vive o SENHOR Deus!",
+    "source": "bible.com:A21(2645)",
+    "corroborated_by": [
+      "bibliatodo.com:almeida-seculo-21"
+    ],
+    "note": "truncado na origem (openlp + bolls ALM21 cortam igual); restaurado de fonte completa"
+  },
+  {
+    "book": "EZK",
+    "chapter": 46,
+    "verse": 12,
+    "was": "Quando o príncipe trouxer uma oferta voluntária, holocausto, ou ofertas pacíficas, como oferta voluntária ao",
+    "now": "Quando o príncipe trouxer uma oferta voluntária, holocausto, ou ofertas pacíficas, como oferta voluntária ao SENHOR, a porta que dá para o oriente será aberta, e ele oferecerá seu holocausto e suas ofertas pacíficas, como tiver feito no dia de sábado. Então sairá, e a porta será fechada depois que ele sair.",
+    "source": "bible.com:A21(2645)",
+    "corroborated_by": [
+      "bibliatodo.com:almeida-seculo-21"
+    ],
+    "note": "truncado na origem (openlp + bolls ALM21 cortam igual); restaurado de fonte completa"
+  }
+]

--- a/data/corrections/JFAA.json
+++ b/data/corrections/JFAA.json
@@ -1,0 +1,50 @@
+[
+  {
+    "book": "EXO",
+    "chapter": 26,
+    "verse": 27,
+    "was": "e cinco para as tábuas do outro lado do tabernáculo, bem como c6 azeite para a luz, especiarias para o óleo da unção e para o para o ocidente.",
+    "now": "e cinco para as tábuas do outro lado do tabernáculo, bem como o azeite para a luz, especiarias para o óleo da unção e para o para o ocidente.",
+    "source": "thiagobodruk/biblia:aa",
+    "corroborated_by": [
+      "bibliaonline.com.br:aa"
+    ],
+    "note": "marcador de nota colado na palavra (le23/le5/le9/c6); restaurado"
+  },
+  {
+    "book": "JDG",
+    "chapter": 9,
+    "verse": 4,
+    "was": "E deram-lhe setenta siclos de prata, da casa de Baal-Berite, com os quais alugou Abimeleque alguns homens ociosos e le9",
+    "now": "E deram-lhe setenta siclos de prata, da casa de Baal-Berite, com os quais alugou Abimeleque alguns homens ociosos e levianas, que o seguiram;",
+    "source": "thiagobodruk/biblia:aa",
+    "corroborated_by": [
+      "bibliaonline.com.br:aa"
+    ],
+    "note": "marcador de nota colado na palavra (le23/le5/le9/c6); restaurado"
+  },
+  {
+    "book": "JER",
+    "chapter": 8,
+    "verse": 11,
+    "was": "E curam a ferida da filha de meu povo le23",
+    "now": "E curam a ferida da filha de meu povo levianamente, dizendo: Paz, paz; quando não há paz.",
+    "source": "thiagobodruk/biblia:aa",
+    "corroborated_by": [
+      "bibliaonline.com.br:aa"
+    ],
+    "note": "marcador de nota colado na palavra (le23/le5/le9/c6); restaurado"
+  },
+  {
+    "book": "1TI",
+    "chapter": 5,
+    "verse": 11,
+    "was": "Mas rejeita as viúvas mais novas, porque, quando se tornam le5",
+    "now": "Mas rejeita as viúvas mais novas, porque, quando se tornam levianas contra Cristo, querem casar-se;",
+    "source": "thiagobodruk/biblia:aa",
+    "corroborated_by": [
+      "bibliaonline.com.br:aa"
+    ],
+    "note": "marcador de nota colado na palavra (le23/le5/le9/c6); restaurado"
+  }
+]

--- a/data/corrections/KJF.json
+++ b/data/corrections/KJF.json
@@ -1,0 +1,14 @@
+[
+  {
+    "book": "2SA",
+    "chapter": 13,
+    "verse": 27,
+    "was": "Absalão, porém, insistiu com ele para",
+    "now": "Absalão, porém, insistiu com ele para que deixasse Amnom e todos os filhos do rei irem com ele.",
+    "source": "bibliaonline.com.br:bkj",
+    "corroborated_by": [
+      "bkjfiel.com.br"
+    ],
+    "note": "truncado na origem (openlp); restaurado, versificação confere com v25/26/28"
+  }
+]

--- a/data/worklist/AS21.md
+++ b/data/worklist/AS21.md
@@ -1,15 +1,13 @@
 # Worklist — AS21
 
-## high (20)
+## high (18)
 - JOS 12:2 — verse much shorter than other versions (102 vs median 216 chars)
 - JDG 11:5 — verse much shorter than other versions (49 vs median 105 chars)
 - 1KI 8:18 — verse much shorter than other versions (48 vs median 114 chars)
 - 2KI 5:19 — verse much shorter than other versions (29 vs median 72 chars)
 - 2KI 13:20 — verse much shorter than other versions (44 vs median 101 chars)
 - ISA 37:15 — verse much shorter than other versions (17 vs median 35 chars)
-- JER 44:26 — verse much shorter than other versions (107 vs median 262 chars)
 - EZK 41:26 — verse much shorter than other versions (70 vs median 143 chars)
-- EZK 46:12 — verse much shorter than other versions (108 vs median 314 chars)
 - MAT 4:6 — verse much shorter than other versions (77 vs median 196 chars)
 - MAT 13:14 — verse much shorter than other versions (48 vs median 134 chars)
 - MAT 21:13 — verse much shorter than other versions (27 vs median 121 chars)
@@ -22,7 +20,7 @@
 - 2CO 2:11 — verse much shorter than other versions (40 vs median 85 chars)
 - HEB 2:12 — verse much shorter than other versions (8 vs median 91 chars)
 
-## low (411)
+## low (409)
 - GEN 10:13 — missing terminal punctuation
 - GEN 10:26 — missing terminal punctuation
 - GEN 10:27 — missing terminal punctuation
@@ -365,13 +363,11 @@
 - JER 25:22 — missing terminal punctuation
 - JER 37:11 — missing terminal punctuation
 - JER 38:7 — missing terminal punctuation
-- JER 44:26 — missing terminal punctuation
 - LAM 3:42 — missing terminal punctuation
 - EZK 20:12 — missing terminal punctuation
 - EZK 30:14 — missing terminal punctuation
 - EZK 38:4 — missing terminal punctuation
 - EZK 38:5 — missing terminal punctuation
-- EZK 46:12 — missing terminal punctuation
 - EZK 47:15 — missing terminal punctuation
 - HOS 13:7 — missing terminal punctuation
 - AMO 7:12 — missing terminal punctuation

--- a/data/worklist/JFAA.md
+++ b/data/worklist/JFAA.md
@@ -1,15 +1,14 @@
 # Worklist — JFAA
 
-## high (7)
+## high (6)
 - 2KI 5:19 — verse much shorter than other versions (29 vs median 72 chars)
-- JER 8:11 — verse much shorter than other versions (42 vs median 100 chars)
 - MRK 12:22 — verse much shorter than other versions (40 vs median 94 chars)
 - JHN 19:16 — verse much shorter than other versions (40 vs median 80 chars)
 - 2CO 2:11 — verse much shorter than other versions (41 vs median 85 chars)
 - 2CO 12:6 — verse much shorter than other versions (72 vs median 181 chars)
 - 2CO 13:13 — verse much shorter than other versions (27 vs median 58 chars)
 
-## low (497)
+## low (496)
 - GEN 5:23 — missing terminal punctuation
 - GEN 6:6 — missing terminal punctuation
 - GEN 10:13 — missing terminal punctuation
@@ -418,7 +417,6 @@
 - ISA 51:9 — missing terminal punctuation
 - ISA 58:2 — missing terminal punctuation
 - JER 3:4 — missing terminal punctuation
-- JER 8:11 — missing terminal punctuation
 - JER 28:13 — missing terminal punctuation
 - JER 36:29 — missing terminal punctuation
 - JER 37:3 — missing terminal punctuation

--- a/data/worklist/KJF.md
+++ b/data/worklist/KJF.md
@@ -1,13 +1,12 @@
 # Worklist — KJF
 
-## high (5)
-- 2SA 13:27 — verse much shorter than other versions (37 vs median 91 chars)
+## high (4)
 - MRK 3:16 — verse much shorter than other versions (26 vs median 68 chars)
 - ACT 3:20 — verse much shorter than other versions (51 vs median 113 chars)
 - 2CO 13:13 — verse much shorter than other versions (27 vs median 58 chars)
 - 1TH 2:7 — verse much shorter than other versions (65 vs median 147 chars)
 
-## low (434)
+## low (433)
 - GEN 24:13 — missing terminal punctuation
 - GEN 28:7 — missing terminal punctuation
 - GEN 36:9 — missing terminal punctuation
@@ -62,7 +61,6 @@
 - 1SA 13:1 — missing terminal punctuation
 - 2SA 5:14 — missing terminal punctuation
 - 2SA 8:9 — missing terminal punctuation
-- 2SA 13:27 — missing terminal punctuation
 - 2SA 23:24 — missing terminal punctuation
 - 2SA 23:25 — missing terminal punctuation
 - 2SA 23:26 — missing terminal punctuation


### PR DESCRIPTION
Sete versículos que estavam truncados na origem (o SQLite/feed antigo), achados pela varredura da worklist. Cada um certificado por duas fontes independentes antes de entrar:

- JFAA (4): número de nota colado na palavra "levi…" — `le23`→levianamente, `le5`→levianas, `le9`→levianos, e um `c6` solto na Êx 26:27. thiagobodruk `aa` + bibliaonline `/aa`, palavra por palavra.
- AS21 (2): Jr 44:26 e Ez 46:12 cortados no meio da frase. bible.com (A21) + bibliatodo. O bolls ALM21 repete a mesma truncagem, então não valia como testemunha.
- KJF (1): 2Sm 13:27 cortado em "para". bibliaonline `/bkj` + bkjfiel.com.br; versificação conferida contra os vs. 25/26/28.

Refs em `data/corrections/<VERSÃO>.json` com fonte e testemunhas, protegidos de sobrescrita.

Worklists: AS21 20→18, JFAA 7→6, KJF 5→4. Testes 55/55, ruff limpo.